### PR TITLE
fix: Enable auto-release workflow triggers

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-      - '.github/**'
       - 'README.md'
       - 'LICENSE'
       - 'CLAUDE.md'


### PR DESCRIPTION
## Summary
- Remove `.github/**` from paths-ignore in auto-release workflow
- This allows the workflow to trigger when GitHub Actions files are modified
- Previous merge didn't create a release because workflow files were ignored

## Test plan
- [ ] Verify auto-release workflow triggers after this PR is merged
- [ ] Confirm v0.0.1 release is created automatically
- [ ] Check that plugin.zip is built and uploaded to releases

🤖 Generated with [Claude Code](https://claude.ai/code)